### PR TITLE
FIX 3588

### DIFF
--- a/snowpack/src/commands/dev.ts
+++ b/snowpack/src/commands/dev.ts
@@ -621,7 +621,7 @@ export async function startServer(
       if (!fileLocationExists) {
         throw new NotFoundError(reqPath, [attemptedFileLoc]);
       }
-      let foundType = path.extname(reqPath);
+      let foundType = path.extname(resourcePath);
       if (!foundType && attemptedFileLoc.endsWith('.html')) foundType = '.html';
       if (IS_DOTFILE_REGEX.test(reqPath)) foundType = '';
       foundFile = {


### PR DESCRIPTION
resourceType must be derived from resourcePath (where .proxy.js was stripped off), not from requestPath.

## Changes

When using a monorepo, sibling packages are being linked. In this case, the resource type of a proxied (static) asset was not correctly derived from the actual resource that was requested, but from the proxied request (always .js)

<!-- Before/after screenshots may be helpful.  -->

## Testing

<!-- How was this change tested? -->
no tests added, nor did I test this code change.

## Docs

bug fix only
https://github.com/snowpackjs/snowpack/issues/3588